### PR TITLE
Experimental X11 grab

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,14 @@
+# Horture architecture
+
+Split into multiple modules, each responsible for a simple task:
+
+* CommandModule:
+  - This module provides external inputs to horture. For example a module
+    listening to channel point redemptions on Twitch for specific channel.
+* Command&Control:
+  - Horture user direct interface.
+  - Allows setting runtime parameters, which application to horture and direct
+    control flow between other modules.
+* ExecutionModule:
+  - The interactive module which visualizes commands issued to horture.
+  - Uses OpenGL.

--- a/TODO
+++ b/TODO
@@ -1,0 +1,24 @@
+# Possible performance optimizations
+
+* Use getShmImage extension for X11 server.
+* TODO: Use double buffering when creating the texture, s.t. we do not
+  need to wait for OpenGL to finish drawing a frame before updating to
+  a new one?
+  Fetch xImage in separate thread -> push into pipeline for main
+  thread with ptr to preexisting texture?
+* Use compositeoverlaywindow for masking:
+   Window overlay_window = XCompositeGetOverlayWindow(display, root);
+   Make GLFW Window with proper size and location child of overlay_window
+   via reparenting.
+   DONE?!
+    -- overlay <- xCompositeGetOverlayWindow dp root
+    -- xCompositeRedirectWindow dp w CompositeRedirectAutomatic
+    -- mapWindow dp overlay
+    -- reparentWindow dp meW overlay 0 0
+
+# Notes
+* NOTE: Need to set the events we are interested in ON the window we are
+  listening on!
+* NOTE: A RUNNING compositemanager is ALSO required! MAYBE?
+* zPixmap required!
+  https://stackoverflow.com/questions/34662275/xgetimage-takes-a-lot-of-time-to-run

--- a/TODO
+++ b/TODO
@@ -15,6 +15,9 @@
     -- xCompositeRedirectWindow dp w CompositeRedirectAutomatic
     -- mapWindow dp overlay
     -- reparentWindow dp meW overlay 0 0
+* Use compositor instead of GLFW workaround...
+    -- set_override_redirect ptr True
+    -- changeWindowAttributes dp meW cWOverrideRedirect ptr
 
 # Notes
 * NOTE: Need to set the events we are interested in ON the window we are

--- a/TODO
+++ b/TODO
@@ -25,3 +25,13 @@
 * NOTE: A RUNNING compositemanager is ALSO required! MAYBE?
 * zPixmap required!
   https://stackoverflow.com/questions/34662275/xgetimage-takes-a-lot-of-time-to-run
+
+# Features
+* Toggle ClearScreen (background)
+* Zoom monitor away
+* Gradually increase visual screen shaking
+* Flip screen (X and/or Y)
+* Rollercoaster: Move screen and add delayed camera tracking
+* Spawn GIF (+optional add sound) at random location for ~X seconds
+* Your Highness, texture shader randomizing colors
+* FLASHBANG

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -112,7 +112,7 @@ main' w = do
         ImageRGBA8 (Codec.Picture.Image w h _) -> (w, h)
         _ -> error "decoding gif image"
   withArray imgsL $ \ptr -> do
-    let pixelData = PixelData RGBA UnsignedByte ptr
+    let pixelData = PixelData BGRA UnsignedInt8888Rev ptr
     texImage3D
       Texture2DArray
       NoProxy
@@ -143,7 +143,9 @@ main' w = do
   GL.clearColor $= Color4 0.1 0.1 0.1 1
 
   screenTexObject <- genObjectName @TextureObject
-  _ <- xCompositeRedirectWindow dp w CompositeRedirectAutomatic
+  -- CompositeRedirectManual to avoid unnecessarily drawing the captured
+  -- window, which is overlayed anyway by our application.
+  _ <- xCompositeRedirectWindow dp w CompositeRedirectManual
   pm <- xCompositeNameWindowPixmap dp w
   print $ "Retrieved composite window pixmap: " <> show pm
 
@@ -151,7 +153,7 @@ main' w = do
       wh = wa_height attr
   GLFW.setFramebufferSizeCallback glW (Just resizeWindow')
 
-  let !anyPixelData = PixelData BGRA UnsignedInt8888Rev nullPtr
+  let !anyPixelData = PixelData BGRA UnsignedByte nullPtr
   textureBinding Texture2D $= Just screenTexObject
   texImage2D
     Texture2D
@@ -221,6 +223,7 @@ main' w = do
             _gifIndex = texIndex,
             _backgroundColor = Color4 0.1 0.1 0.1 1
           }
+  -- TODO: Shutdown xWin when application closes.
   runHorture hs hc (playScene scene)
   print "Done..."
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -13,15 +12,9 @@ module Main where
 --                -> Upload image to GPU with OpenGL
 --                -> Postprocess and draw to window
 
-import Control.Concurrent (forkIO, forkOS)
-import Control.Concurrent.Chan.Synchronous
-import Control.DeepSeq (force)
-import Control.Exception (evaluate)
 import Control.Monad.Except
 import Data.Bits
-import Data.ByteString.Char8 (ByteString, pack)
-import Data.Functor ((<&>))
-import Data.List (find)
+import Data.List (elem, find)
 import Data.Maybe
 import Data.Word
 import Foreign.C.Types
@@ -31,77 +24,77 @@ import Foreign.Ptr
 import Foreign.Storable
 import GHC.ForeignPtr
 import Graphics.GLUtil as Util hiding (throwError)
-import Graphics.Rendering.OpenGL as GL hiding (Color)
-import Graphics.Rendering.OpenGL.GL.Shaders.Uniform
-import Graphics.Rendering.OpenGL.GL.Texturing.Specification
+import Graphics.Rendering.OpenGL as GL hiding (Color, flush)
 import qualified Graphics.UI.GLFW as GLFW
 import Graphics.X11 hiding (resizeWindow)
 import Graphics.X11.Xlib.Extras
 import Graphics.X11.Xlib.Types
+import Horture
+import Options.Applicative
+  ( Parser,
+    argument,
+    auto,
+    execParser,
+    fullDesc,
+    help,
+    helper,
+    info,
+    long,
+    metavar,
+    progDesc,
+    short,
+    (<**>),
+  )
 import System.Clock
 import System.Exit
 import Text.RawString.QQ
 
+newtype CmdLineArgs = CLA
+  { target :: Window
+  }
+
 main :: IO ()
-main = findTest
-
-updateTest :: IO ()
-updateTest = do
-  dp <- openDisplay ""
-  let ds = defaultScreen dp
-      cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  Just w <- findClassName dp w "private"
-  attr <- getWindowAttributes dp w
-  print $ "Window with ID: " <> show w
-  print $ "Initial window dimension: " <> show (wa_width attr, wa_height attr)
-  print $ "Window your event mask: " <> (show . wa_your_event_mask $ attr)
-  print $ "Window all event mask: " <> (show . wa_all_event_masks $ attr)
-  -- NOTE: Need to set the events we are interested in ON the window we are
-  -- listening on!
-  allocaSetWindowAttributes $ \ptr -> do
-    _ <- set_event_mask ptr structureNotifyMask
-    changeWindowAttributes dp w cWEventMask ptr
-
-  chan <- newChan @(CInt, CInt)
-  forkIO (listenResizeEvent dp w chan)
-
-  print "Trying to read..."
-  go dp w chan
-  print "Done..."
+main = execParser opts >>= main'
   where
-    go dp w chan = do
-      tryReadChan chan >>= \case
-        Success newSize -> print newSize
-        _ -> return ()
-      go dp w chan
+    opts =
+      info
+        (cmdLineParser <**> helper)
+        (fullDesc <> progDesc "Horture yourself 🤡")
 
-findTest :: IO ()
-findTest = do
+cmdLineParser :: Parser CmdLineArgs
+cmdLineParser =
+  CLA
+    <$> argument
+      (auto @Window)
+      ( metavar "WINDOW_ID"
+          <> help
+            "Target window id to 'horture'."
+      )
+
+main' :: CmdLineArgs -> IO ()
+main' (CLA w) = do
   glW <- initGLFW
   (vao, vbo, veo, prog) <- initResources
   dp <- openDisplay ""
   let ds = defaultScreen dp
       cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  Just w <- findClassName dp w "private"
-  attr <- getWindowAttributes dp w
+  root <- rootWindow dp ds
 
-  -- NOTE: Need to set the events we are interested in ON the window we are
-  -- listening on!
+  Just (_, meW) <- findMe root dp hortureName
+  allocaSetWindowAttributes $ \ptr -> do
+    _ <- set_override_redirect ptr True
+    changeWindowAttributes dp meW cWEventMask ptr
+
+  attr <- getWindowAttributes dp w
   allocaSetWindowAttributes $ \ptr -> do
     _ <- set_event_mask ptr structureNotifyMask
     changeWindowAttributes dp w cWEventMask ptr
+  print "Set window attributes"
 
-  chan <- newChan @(CInt, CInt)
-  forkOS (listenResizeEvent dp w chan)
-
-  -- NOTE: A RUNNING compositemanager is ALSO required!
   res <- xCompositeQueryExtension dp
   when (isNothing res) $
     print "xCompositeExtension is missing!" >> exitFailure
-
-  xCompositeRedirectWindow dp w CompositeRedirectAutomatic
+  print "Queried composite extension"
 
   bindVertexArrayObject $= Just vao
   bindBuffer ArrayBuffer $= Just vbo
@@ -113,28 +106,30 @@ findTest = do
   bindBuffer ElementArrayBuffer $= Just veo
   withArray vertsElement $ \ptr -> bufferData ElementArrayBuffer $= (fromIntegral vertsElementSize, ptr, StaticDraw)
 
-  tex <- genObjectName @TextureObject
+  GL.clearColor $= Color4 0.1 0.1 0.1 1
+
+  tex01 <- genObjectName @TextureObject
   pm <- xCompositeNameWindowPixmap dp w
+  print "Retrieved composite window pixmap"
 
-  -- Use compositeoverlaywindow for masking:
-  --     Window overlay_window = XCompositeGetOverlayWindow(display, root);
-  --     Make GLFW Window with proper size and location child of overlay_window
-  --     via reparenting.
-  --     DONE?!
+  let ww = wa_width attr
+      wh = wa_height attr
+  GLFW.setFramebufferSizeCallback glW (Just resizeWindow)
 
+  let !anyPixelData = PixelData BGRA UnsignedInt8888Rev nullPtr
+  textureBinding Texture2D $= Just tex01
+  texImage2D
+    Texture2D
+    NoProxy
+    0
+    RGBA'
+    (TextureSize2D (fromIntegral ww) (fromIntegral wh))
+    0
+    anyPixelData
+
+  GLFW.setWindowSize glW (fromIntegral $ wa_width attr) (fromIntegral $ wa_height attr)
+  GLFW.setWindowPos glW (fromIntegral . wa_x $ attr) (fromIntegral . wa_y $ attr)
   let update pm (ww, wh) = do
-        start <- getTime Monotonic
-
-        (pm, (ww, wh)) <-
-          tryReadChan chan >>= \case
-            Success newSize -> do
-              print "Window update caught!"
-              freePixmap dp pm
-              pm <- xCompositeNameWindowPixmap dp w
-              return (pm, newSize)
-            _ -> return (pm, (ww, wh))
-
-        (glww, glwh) <- GLFW.getWindowSize glW
         i <-
           getImage
             dp
@@ -144,30 +139,21 @@ findTest = do
             (fromIntegral ww)
             (fromIntegral wh)
             0xFFFFFFFF
-            -- zPixmap required!
-            -- https://stackoverflow.com/questions/34662275/xgetimage-takes-a-lot-of-time-to-run
             zPixmap
 
         src <- ximageData i
-        let pixelData = PixelData BGRA UnsignedByte src
-        textureBinding Texture2D $= Just tex
-        texImage2D
+        let pixelData = PixelData BGRA UnsignedInt8888Rev src
+        texSubImage2D
           Texture2D
-          NoProxy
           0
-          RGBA'
+          (TexturePosition2D 0 0)
           (TextureSize2D (fromIntegral ww) (fromIntegral wh))
-          0
           pixelData
 
         generateMipmap' Texture2D
-        activeTexture $= TextureUnit 0
-        texUniform <- uniformLocation prog "texture1"
-        uniform @GLint texUniform $= 0
 
         destroyImage i
 
-        GL.clearColor $= Color4 0.1 0.1 0.1 1
         GL.clear [ColorBuffer]
 
         bindVertexArrayObject $= Just vao
@@ -176,440 +162,61 @@ findTest = do
         GLFW.swapBuffers glW
         GLFW.pollEvents
 
-        end <- getTime Monotonic
-        let dt = nsec (end - start)
-            frameTime = fromIntegral dt / (10 ^ 6)
-        print $ "Frametime: " <> show frameTime <> " ms"
+        (pm, (ww, wh)) <- allocaXEvent $ \evptr -> do
+          doIt <- checkWindowEvent dp w structureNotifyMask evptr
+          if doIt
+            then do
+              getEvent evptr >>= \case
+                ConfigureEvent {..} -> do
+                  -- Retrieve a new pixmap.
+                  newPm <- xCompositeNameWindowPixmap dp w
+                  -- Update reference, aspect ratio & destroy old pixmap.
+                  freePixmap dp pm
+                  -- Update overlay window with new aspect ratio.
+                  let glw = fromIntegral ev_width
+                      glh = fromIntegral ev_height
+                  GLFW.setWindowSize glW glw glh
+                  attr <- getWindowAttributes dp w
+                  GLFW.setWindowPos glW (fromIntegral ev_x) (fromIntegral ev_y)
+                  (glW, glH) <- GLFW.getFramebufferSize glW
+                  let !anyPixelData = PixelData BGRA UnsignedInt8888Rev nullPtr
+                  -- Update texture bindings!
+                  textureBinding Texture2D $= Just tex01
+                  texImage2D
+                    Texture2D
+                    NoProxy
+                    0
+                    RGBA'
+                    (TextureSize2D (fromIntegral ev_width) (fromIntegral ev_height))
+                    0
+                    anyPixelData
+                  return (newPm, (ev_width, ev_height))
+                _ -> return (pm, (ww, wh))
+            else return (pm, (ww, wh))
 
         update pm (ww, wh)
 
-  update pm (wa_width attr, wa_height attr)
+  update pm (ww, wh)
   print "Done..."
 
-xtest :: IO ()
-xtest = do
-  dp <- openDisplay ""
-  let ds = defaultScreen dp
-      cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  (root, parent, childs) <- queryTree dp w
-  res <-
-    mapM
-      ( \c ->
-          fetchName dp c >>= \case
-            Nothing -> return ("", c)
-            Just w -> return (w, c)
-      )
-      childs
-      <&> filter ((/=) "" . fst)
-
-  alloca $ \ptr -> do
-    mapM
-      ( \c -> do
-          s <- xGetTextProperty dp c ptr wM_CLASS
-          when (s /= 0) $ peek ptr >>= wcTextPropertyToTextList dp >>= print
-      )
-      childs
-  print "Done..."
-
-main'' :: IO ()
-main'' = do
-  dp <- openDisplay ""
-  let ds = defaultScreen dp
-      cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  attr <- getWindowAttributes dp w
-
-  let ww = fromIntegral $ wa_width attr
-      wh = fromIntegral $ wa_height attr
-      n = 6
-      loop :: Int -> IO Int
-      loop i = do
-        !img <-
-          getImage
-            dp
-            w
-            0
-            0
-            (fromIntegral ww)
-            (fromIntegral wh)
-            0xFFFFFFFF
-            zPixmap
-
-        ximageBytesPerLine img >>= \m -> print $ "BytesPerLine: " <> show m
-        ximageOffset img >>= \m -> print $ "Offset: " <> show m
-        ximagebitsPerPixel img >>= \m -> print $ "BitsPerPixel: " <> show m
-
-        -- GetPixel query.
-        let x = 1
-            y = 0
-            px = getPixel img x y
-        queryColor dp cm (Color (fromIntegral px) 0 0 0 0)
-          >>= \(Color _ r g b _) -> print $ "GetPixel: " <> show (r, g, b)
-
-        -- Custom query.
-        buf <- ximageData img
-        let stride = 4
-            -- 3840x1080
-            idx = 3840 * 1080 * stride
-        peekByteOff @Word8 buf (idx + 0)
-          >>= \r ->
-            peekByteOff @Word8 buf (idx + 4)
-              >>= \g ->
-                peekByteOff @Word8 buf (idx + 8)
-                  >>= \b -> print $ "Image Inspect: " <> show (r, g, b)
-        if i < n then loop (i + 1) else return i
-
-  start <- getTime Monotonic
-  r <- loop 0
-  end <- getTime Monotonic
-
-  let dt = nsec (end - start)
-      frameTime = fromIntegral dt / fromIntegral n
-
-  print $ "r: " <> show r
-  print $ "dt: " <> show dt
-  print $ "n: " <> show n
-  print $ "FrameTime (ms): " <> show (frameTime / (10 ^ 6))
-
-  print "Done..."
-
-main''' :: IO ()
-main''' = do
-  glW <- initGLFW
-  (vao, vbo, veo, prog) <- initResources
-  dp <- openDisplay ""
-  let ds = defaultScreen dp
-      cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  attr <- getWindowAttributes dp w
-
-  bindVertexArrayObject $= Just vao
-  bindBuffer ArrayBuffer $= Just vbo
-  withArray verts $ \ptr -> bufferData ArrayBuffer $= (fromIntegral planeVertsSize, ptr, StaticDraw)
-  vertexAttribPointer (AttribLocation 0) $= (ToFloat, VertexArrayDescriptor 3 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr 0))
-  vertexAttribArray (AttribLocation 0) $= Enabled
-  vertexAttribPointer (AttribLocation 1) $= (ToFloat, VertexArrayDescriptor 2 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr (3 * floatSize)))
-  vertexAttribArray (AttribLocation 1) $= Enabled
-  bindBuffer ElementArrayBuffer $= Just veo
-  withArray vertsElement $ \ptr -> bufferData ElementArrayBuffer $= (fromIntegral vertsElementSize, ptr, StaticDraw)
-
-  let ww = fromIntegral $ wa_width attr
-      wh = fromIntegral $ wa_height attr
-      update = do
-        (glww, glwh) <- GLFW.getWindowSize glW
-        i <-
-          getImage
-            dp
-            w
-            0
-            0
-            (fromIntegral ww)
-            (fromIntegral wh)
-            0xFFFFFFFF
-            -- zPixmap required!
-            -- https://stackoverflow.com/questions/34662275/xgetimage-takes-a-lot-of-time-to-run
-            zPixmap
-
-        src <- ximageData i
-        let pixelData = PixelData BGRA UnsignedByte src
-
-        tex <- genObjectName @TextureObject
-        textureBinding Texture2D $= Just tex
-        texImage2D
-          Texture2D
-          NoProxy
-          0
-          RGBA'
-          (TextureSize2D (fromIntegral ww) (fromIntegral wh))
-          0
-          pixelData
-
-        generateMipmap' Texture2D
-        activeTexture $= TextureUnit 0
-        texUniform <- uniformLocation prog "texture1"
-        uniform @GLint texUniform $= 0
-
-        destroyImage i
-
-        GL.clearColor $= Color4 0.1 0.1 0.1 1
-        GL.clear [ColorBuffer]
-
-        bindVertexArrayObject $= Just vao
-        drawElements Triangles 6 UnsignedInt nullPtr
-
-        GLFW.swapBuffers glW
-        GLFW.pollEvents
-        update
-
-  update
-  print "Done..."
-
-main' :: IO ()
-main' = do
-  glW <- initGLFW
-  (vao, vbo, veo, prog) <- initResources
-  dp <- openDisplay ""
-  let ds = defaultScreen dp
-      cm = defaultColormap dp ds
-  w <- rootWindow dp ds
-  attr <- getWindowAttributes dp w
-
-  bindVertexArrayObject $= Just vao
-  bindBuffer ArrayBuffer $= Just vbo
-  withArray verts $ \ptr -> bufferData ArrayBuffer $= (fromIntegral planeVertsSize, ptr, StaticDraw)
-  vertexAttribPointer (AttribLocation 0) $= (ToFloat, VertexArrayDescriptor 3 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr 0))
-  vertexAttribArray (AttribLocation 0) $= Enabled
-  vertexAttribPointer (AttribLocation 1) $= (ToFloat, VertexArrayDescriptor 2 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr (3 * floatSize)))
-  vertexAttribArray (AttribLocation 1) $= Enabled
-  bindBuffer ElementArrayBuffer $= Just veo
-  withArray vertsElement $ \ptr -> bufferData ElementArrayBuffer $= (fromIntegral vertsElementSize, ptr, StaticDraw)
-
-  let ww = fromIntegral $ wa_width attr
-      wh = fromIntegral $ wa_height attr
-      update = do
-        (glww, glwh) <- GLFW.getWindowSize glW
-        i <-
-          getImage
-            dp
-            w
-            0
-            0
-            (fromIntegral ww)
-            (fromIntegral wh)
-            0xFFFFFFFF
-            -- zPixmap required!
-            -- https://stackoverflow.com/questions/34662275/xgetimage-takes-a-lot-of-time-to-run
-            zPixmap
-
-        -- TODO: Make efficient...
-        let sz = ww * wh
-        src <- mallocArray @Word64 $ ww * wh
-        iterate' (<= sz) $ \idx ->
-          let x = fromIntegral $ idx `mod` ww
-              y = fromIntegral $ idx `div` ww
-              px = getPixel i x y
-           in queryColor dp cm (Color (fromIntegral px) 0 0 0 0)
-                >>= \(Color _ r g b _) -> do
-                  pokeByteOff @Word16 src (idx * 8 + 0) r
-                  pokeByteOff @Word16 src (idx * 8 + 2) g
-                  pokeByteOff @Word16 src (idx * 8 + 4) b
-                  pokeByteOff @Word16 src (idx * 8 + 6) 0xffff
-
-        let pixelData = PixelData RGBA UnsignedShort src
-
-        tex <- genObjectName @TextureObject
-        textureBinding Texture2D $= Just tex
-        texImage2D
-          Texture2D
-          NoProxy
-          0
-          RGB'
-          (TextureSize2D (fromIntegral ww) (fromIntegral wh))
-          0
-          pixelData
-
-        generateMipmap' Texture2D
-        activeTexture $= TextureUnit 0
-        texUniform <- uniformLocation prog "texture1"
-        uniform @GLint texUniform $= 0
-
-        free src
-        destroyImage i
-
-        GL.clearColor $= Color4 0.1 0.1 0.1 1
-        GL.clear [ColorBuffer]
-
-        bindVertexArrayObject $= Just vao
-        drawElements Triangles 6 UnsignedInt nullPtr
-
-        GLFW.swapBuffers glW
-        GLFW.pollEvents
-        update
-
-  update
-  print "Done..."
-
-verts :: [Float]
-verts = [-1, -1, 0, 0, 1, -1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, -1, 0, 1, 1]
-
-vertsElement :: [GLuint]
-vertsElement = [0, 1, 2, 0, 2, 3]
-
-uintSize :: Int
-uintSize = sizeOf @GLuint undefined
-
-floatSize :: Int
-floatSize = sizeOf @Float undefined
-
-planeVertsSize :: Int
-planeVertsSize = length verts * floatSize
-
-vertsElementSize :: Int
-vertsElementSize = length vertsElement * uintSize
-
-imgPtr :: Image -> Ptr Image
-imgPtr (Image p) = p
-
-szCInt :: Int
-szCInt = sizeOf @CInt undefined
-
-ximageData :: Image -> IO (Ptr Word8)
-ximageData (Image p) = peek (plusPtr @Image @(Ptr CIntPtr) p xdataPtr) >>= \buf -> return . castPtr $ buf
-  where
-    szCint = sizeOf @CInt undefined
-    xdataPtr = 4 * szCint
-
-ximagebitsPerPixel :: Image -> IO CInt
-ximagebitsPerPixel (Image p) = peekByteOff @CInt (castPtr p) xbitsPerPixel
-  where
-    szCint = sizeOf @CInt undefined
-    szPtr = sizeOf @CIntPtr undefined
-    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint
-
-ximageBytesPerLine :: Image -> IO CInt
-ximageBytesPerLine (Image p) = peekByteOff @CInt (castPtr p) xbytesPerLine
-  where
-    szCint = sizeOf @CInt undefined
-    szPtr = sizeOf @CIntPtr undefined
-    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
-
-ximageOffset :: Image -> IO CInt
-ximageOffset (Image p) = peekByteOff @CInt (castPtr p) xoffset
-  where
-    szCint = sizeOf @CInt undefined
-    szPtr = sizeOf @CIntPtr undefined
-    xwidth = 0
-    xheight = szCint
-    xoffset = 2 * szCint
-    xformat = 3 * szCint
-    xdataPtr = 4 * szCint
-    xbyteorder = 4 * szCint + szPtr
-    xbitmapUnit = 4 * szCint + szPtr + szCint
-    xbitmapBitOrder = 4 * szCint + szPtr + 2 * szCint
-    xbitmapPad = 4 * szCint + szPtr + 3 * szCint
-    xdepth = 4 * szCint + szPtr + 4 * szCint
-    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
-    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint
-
-initGLFW :: IO GLFW.Window
-initGLFW = do
-  GLFW.init
-  GLFW.defaultWindowHints
-  win <-
-    GLFW.createWindow 512 512 "Horture" Nothing Nothing >>= \case
-      Nothing -> throwError . userError $ "Failed to create GLFW window"
-      Just win -> return win
-  GLFW.makeContextCurrent (Just win)
-  GLFW.setWindowSizeCallback win (Just resizeWindow)
-  GLFW.setKeyCallback win (Just keyPressed)
-  GLFW.setWindowCloseCallback win (Just shutdown)
-  return win
-
-resizeWindow :: GLFW.WindowSizeCallback
-resizeWindow win w h = do
-  GL.viewport $= (GL.Position 0 0, GL.Size (fromIntegral w) (fromIntegral h))
-
-keyPressed :: GLFW.KeyCallback
-keyPressed win GLFW.Key'Escape _ GLFW.KeyState'Pressed _ = shutdown win
-keyPressed win GLFW.Key'Q _ GLFW.KeyState'Pressed _ = shutdown win
-keyPressed _ _ _ _ _ = return ()
-
-shutdown win = do
-  GLFW.destroyWindow win
-  GLFW.terminate
-  void exitSuccess
-
-initResources :: IO (VertexArrayObject, BufferObject, BufferObject, Program)
-initResources = do
-  vao <- genObjectName
-  bindVertexArrayObject $= Just vao
-  vbo <- genObjectName
-  bindBuffer ArrayBuffer $= Just vbo
-  vsp <- loadShaderBS "vertex.shader" VertexShader hortureVertexShader
-  fsp <- loadShaderBS "fragment.shader" FragmentShader hortureFragmentShader
-  prog <- linkShaderProgram [vsp, fsp]
-  currentProgram $= Just prog
-  veo <- genObjectName
-  bindBuffer ArrayBuffer $= Just veo
-  return (vao, vbo, veo, prog)
-
-iterate' :: Monad m => (Int -> Bool) -> (Int -> m ()) -> m ()
-iterate' b f = go 0 b f
-  where
-    go :: Monad m => Int -> (Int -> Bool) -> (Int -> m ()) -> m ()
-    go n b f = when (b n) $ f n >> go (n + 1) b f
-
-hortureVertexShader :: ByteString
-hortureVertexShader =
-  pack
-    [r|
-#version 410
-
-layout (location = 0) in vec3 aPos;
-layout (location = 1) in vec2 aTexCoord;
-
-out vec2 texCoord;
-
-void main() {
-  gl_Position = vec4(aPos, 1.0);
-  texCoord = aTexCoord;
-}
-   |]
-
-hortureFragmentShader :: ByteString
-hortureFragmentShader =
-  pack
-    [r|
-#version 410
-
-in vec2 texCoord;
-
-uniform sampler2D texture1;
-
-out vec4 frag_colour;
-
-void main() {
-  frag_colour = texture(texture1, texCoord);
-}
-    |]
-
-listenResizeEvent :: Display -> Window -> Chan (CInt, CInt) -> IO ()
-listenResizeEvent dp w c = go
-  where
-    go = do
-      allocaXEvent $ \evptr -> do
-        doIt <- checkWindowEvent dp w structureNotifyMask evptr
-        when doIt $ do
-          w' <- get_Window evptr
-          getEvent evptr >>= \case
-            ConfigureEvent {..} -> writeChan c (ev_width, ev_height)
-            _ -> return ()
-      go
-
-findClassName :: Display -> Window -> String -> IO (Maybe Window)
-findClassName dp w n = do
-  (root, parent, childs) <- queryTree dp w
+findMe :: Window -> Display -> String -> IO (Maybe ([[Char]], Window))
+findMe root dp me = do
+  (root, parent, childs) <- queryTree dp root
   alloca $ \ptr -> do
     res <-
       mapM
         ( \c -> do
-            s <- xGetTextProperty dp c ptr wM_CLASS
-            if s /= 0
-              then
-                peek ptr
-                  >>= wcTextPropertyToTextList dp
-                  >>= \ss ->
-                    case find (n ==) ss of
-                      Nothing -> return (Nothing @Window)
-                      Just _ -> print ss >> return (Just c)
-              else return (Nothing @Window)
+            xGetTextProperty dp c ptr wM_CLASS
+            r <- peek ptr >>= wcTextPropertyToTextList dp
+            if not . null $ r
+              then print r >> return (Just (r, c))
+              else return Nothing
         )
         childs
-    case res of
-      [] -> return Nothing
-      fs -> case filter (/= Nothing) fs of
-        -- Xlib how to keep drawing unfocused window:
-        -- https://linux.die.net/man/3/xcompositenamewindowpixmap
-        xs@(_ : _) -> return . last $ xs
-        _ -> return Nothing
+    return . join
+      . find
+        ( \case
+            (Just (ns, c)) -> hortureName `elem` ns
+            _ -> False
+        )
+      $ res

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
 -- Horture
@@ -7,5 +11,210 @@ module Main where
 --                -> Upload image to GPU with OpenGL
 --                -> Postprocess and draw to window
 
+import Control.Monad.Except
+import Data.ByteString.Char8 (ByteString, pack)
+import Data.Word
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import Foreign.Storable
+import Graphics.GLUtil as Util hiding (throwError)
+import Graphics.Rendering.OpenGL as GL hiding (Color)
+import Graphics.Rendering.OpenGL.GL.Shaders.Uniform
+import Graphics.Rendering.OpenGL.GL.Texturing.Specification
+import qualified Graphics.UI.GLFW as GLFW
+import Graphics.X11 hiding (resizeWindow)
+import Graphics.X11.Xlib.Extras
+import Graphics.X11.Xlib.Types
+import System.Exit
+import Text.RawString.QQ
+
 main :: IO ()
-main = print "horture"
+main = do
+  glW <- initGLFW
+  (vao, vbo, veo, prog) <- initResources
+  dp <- openDisplay ""
+  let ds = defaultScreen dp
+      cm = defaultColormap dp ds
+  w <- rootWindow dp ds
+  attr <- getWindowAttributes dp w
+
+  bindVertexArrayObject $= Just vao
+  bindBuffer ArrayBuffer $= Just vbo
+  withArray verts $ \ptr -> bufferData ArrayBuffer $= (fromIntegral planeVertsSize, ptr, StaticDraw)
+  vertexAttribPointer (AttribLocation 0) $= (ToFloat, VertexArrayDescriptor 3 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr 0))
+  vertexAttribArray (AttribLocation 0) $= Enabled
+  vertexAttribPointer (AttribLocation 1) $= (ToFloat, VertexArrayDescriptor 2 Float (fromIntegral $ 5 * floatSize) (plusPtr nullPtr (3 * floatSize)))
+  vertexAttribArray (AttribLocation 1) $= Enabled
+  bindBuffer ElementArrayBuffer $= Just veo
+  withArray vertsElement $ \ptr -> bufferData ElementArrayBuffer $= (fromIntegral vertsElementSize, ptr, StaticDraw)
+
+  let ww = 512 -- wa_width attr
+      wh = 512 -- wa_height attr
+      update = do
+        (glww, glwh) <- GLFW.getWindowSize glW
+        i <-
+          getImage
+            dp
+            w
+            0
+            0
+            (fromIntegral ww)
+            (fromIntegral wh)
+            0xFFFFFFFF
+            xyPixmap
+
+        -- TODO: Make efficient...
+        let sz = ww * wh
+        src <- mallocArray @Word64 $ ww * wh
+        iterate' (<= sz) $ \idx ->
+          let x = fromIntegral $ idx `mod` ww
+              y = fromIntegral $ idx `div` ww
+              px = getPixel i x y
+           in queryColor dp cm (Color (fromIntegral px) 0 0 0 0)
+                >>= \(Color _ r g b _) -> do
+                  pokeByteOff @Word16 src (idx * 8 + 0) r
+                  pokeByteOff @Word16 src (idx * 8 + 2) g
+                  pokeByteOff @Word16 src (idx * 8 + 4) b
+                  pokeByteOff @Word16 src (idx * 8 + 6) 0xffff
+
+        let pixelData = PixelData RGBA UnsignedShort src
+
+        tex <- genObjectName @TextureObject
+        textureBinding Texture2D $= Just tex
+        texImage2D
+          Texture2D
+          NoProxy
+          0
+          RGB'
+          (TextureSize2D (fromIntegral ww) (fromIntegral wh))
+          0
+          pixelData
+
+        generateMipmap' Texture2D
+        activeTexture $= TextureUnit 0
+        texUniform <- uniformLocation prog "texture1"
+        uniform @GLint texUniform $= 0
+
+        free src
+        destroyImage i
+
+        GL.clearColor $= Color4 0.1 0.1 0.1 1
+        GL.clear [ColorBuffer]
+
+        bindVertexArrayObject $= Just vao
+        drawElements Triangles 6 UnsignedInt nullPtr
+
+        GLFW.swapBuffers glW
+        GLFW.pollEvents
+        update
+
+  update
+  print "Done..."
+
+verts :: [Float]
+verts = [-1, -1, 0, 0, 1, -1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, -1, 0, 1, 1]
+
+vertsElement :: [GLuint]
+vertsElement = [0, 1, 2, 0, 2, 3]
+
+uintSize :: Int
+uintSize = sizeOf @GLuint undefined
+
+floatSize :: Int
+floatSize = sizeOf @Float undefined
+
+planeVertsSize :: Int
+planeVertsSize = length verts * floatSize
+
+vertsElementSize :: Int
+vertsElementSize = length vertsElement * uintSize
+
+imgPtr :: Image -> Ptr Image
+imgPtr (Image p) = p
+
+szCInt :: Int
+szCInt = sizeOf @CInt undefined
+
+initGLFW :: IO GLFW.Window
+initGLFW = do
+  GLFW.init
+  GLFW.defaultWindowHints
+  win <-
+    GLFW.createWindow 512 512 "Horture" Nothing Nothing >>= \case
+      Nothing -> throwError . userError $ "Failed to create GLFW window"
+      Just win -> return win
+  GLFW.makeContextCurrent (Just win)
+  GLFW.setWindowSizeCallback win (Just resizeWindow)
+  GLFW.setKeyCallback win (Just keyPressed)
+  GLFW.setWindowCloseCallback win (Just shutdown)
+  return win
+
+resizeWindow :: GLFW.WindowSizeCallback
+resizeWindow win w h = do
+  GL.viewport $= (GL.Position 0 0, GL.Size (fromIntegral w) (fromIntegral h))
+
+keyPressed :: GLFW.KeyCallback
+keyPressed win GLFW.Key'Escape _ GLFW.KeyState'Pressed _ = shutdown win
+keyPressed win GLFW.Key'Q _ GLFW.KeyState'Pressed _ = shutdown win
+keyPressed _ _ _ _ _ = return ()
+
+shutdown win = do
+  GLFW.destroyWindow win
+  GLFW.terminate
+  void exitSuccess
+
+initResources :: IO (VertexArrayObject, BufferObject, BufferObject, Program)
+initResources = do
+  vao <- genObjectName
+  bindVertexArrayObject $= Just vao
+  vbo <- genObjectName
+  bindBuffer ArrayBuffer $= Just vbo
+  vsp <- loadShaderBS "vertex.shader" VertexShader hortureVertexShader
+  fsp <- loadShaderBS "fragment.shader" FragmentShader hortureFragmentShader
+  prog <- linkShaderProgram [vsp, fsp]
+  currentProgram $= Just prog
+  veo <- genObjectName
+  bindBuffer ArrayBuffer $= Just veo
+  return (vao, vbo, veo, prog)
+
+iterate' :: Monad m => (Int -> Bool) -> (Int -> m ()) -> m ()
+iterate' b f = go 0 b f
+  where
+    go :: Monad m => Int -> (Int -> Bool) -> (Int -> m ()) -> m ()
+    go n b f = when (b n) $ f n >> go (n + 1) b f
+
+hortureVertexShader :: ByteString
+hortureVertexShader =
+  pack
+    [r|
+#version 410
+
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoord;
+
+out vec2 texCoord;
+
+void main() {
+  gl_Position = vec4(aPos, 1.0);
+  texCoord = aTexCoord;
+}
+   |]
+
+hortureFragmentShader :: ByteString
+hortureFragmentShader =
+  pack
+    [r|
+#version 410
+
+in vec2 texCoord;
+
+uniform sampler2D texture1;
+
+out vec4 frag_colour;
+
+void main() {
+  frag_colour = texture(texture1, texCoord);
+}
+    |]

--- a/horture.cabal
+++ b/horture.cabal
@@ -72,4 +72,5 @@ executable horture-exe
                     , containers
                     , optparse-applicative
                     , linear
+                    , random
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -49,4 +49,6 @@ executable horture-exe
                     , GLUtil
                     , raw-strings-qq
                     , bytestring
+                    , clock
+                    , deepseq
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -23,6 +23,14 @@ extra-source-files: CHANGELOG.md
 
 library horture-lib
     exposed-modules:  Horture
+                    , Horture.Scene
+                    , Horture.Horture
+                    , Horture.X11
+                    , Horture.Error
+                    , Horture.State
+                    , Horture.Render
+                    , Horture.Object
+                    , Horture.Effect
 
     -- Modules included in this library but not exported.
     -- other-modules:
@@ -40,6 +48,7 @@ library horture-lib
                     , clock
                     , deepseq
                     , synchronous-channels
+                    , JuicyPixels
                     , containers
                     , linear
     ghc-options:

--- a/horture.cabal
+++ b/horture.cabal
@@ -41,6 +41,7 @@ library horture-lib
                     , deepseq
                     , synchronous-channels
                     , containers
+                    , linear
     ghc-options:
                     -Wall
                     -fno-warn-name-shadowing
@@ -70,4 +71,5 @@ executable horture-exe
                     , synchronous-channels
                     , containers
                     , optparse-applicative
+                    , linear
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -43,4 +43,10 @@ executable horture-exe
                     , horture-lib
                     , X11
                     , text
+                    , OpenGL
+                    , mtl
+                    , GLFW-b
+                    , GLUtil
+                    , raw-strings-qq
+                    , bytestring
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -73,4 +73,6 @@ executable horture-exe
                     , optparse-applicative
                     , linear
                     , random
+                    , JuicyPixels
+                    , vector
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -29,6 +29,18 @@ library horture-lib
 
     -- LANGUAGE extensions used by modules in this package. other-extensions:
     build-depends:    base ^>=4.14.3.0
+                    , X11
+                    , text
+                    , OpenGL
+                    , mtl
+                    , GLFW-b
+                    , GLUtil
+                    , raw-strings-qq
+                    , bytestring
+                    , clock
+                    , deepseq
+                    , synchronous-channels
+                    , containers
     ghc-options:
                     -Wall
                     -fno-warn-name-shadowing
@@ -37,10 +49,12 @@ library horture-lib
 
 executable horture-exe
     hs-source-dirs:   app
+    -- other-modules:
     main-is:          Main.hs
     ghc-options:
                     -fno-warn-name-shadowing
                     -threaded
+                    -O2
     build-depends:    base ^>=4.14.3.0
                     , horture-lib
                     , X11
@@ -54,4 +68,6 @@ executable horture-exe
                     , clock
                     , deepseq
                     , synchronous-channels
+                    , containers
+                    , optparse-applicative
     default-language: Haskell2010

--- a/horture.cabal
+++ b/horture.cabal
@@ -27,8 +27,7 @@ library horture-lib
     -- Modules included in this library but not exported.
     -- other-modules:
 
-    -- LANGUAGE extensions used by modules in this package.
-    -- other-extensions:
+    -- LANGUAGE extensions used by modules in this package. other-extensions:
     build-depends:    base ^>=4.14.3.0
     ghc-options:
                     -Wall
@@ -39,6 +38,9 @@ library horture-lib
 executable horture-exe
     hs-source-dirs:   app
     main-is:          Main.hs
+    ghc-options:
+                    -fno-warn-name-shadowing
+                    -threaded
     build-depends:    base ^>=4.14.3.0
                     , horture-lib
                     , X11
@@ -51,4 +53,5 @@ executable horture-exe
                     , bytestring
                     , clock
                     , deepseq
+                    , synchronous-channels
     default-language: Haskell2010

--- a/src/Horture.hs
+++ b/src/Horture.hs
@@ -286,7 +286,7 @@ out vec4 frag_colour;
 void main() {
   vec4 colour = texture(texture1, texCoord);
   // frag_colour = vec4(colour.x+sin(4*texCoord.x+dt), colour.y+cos(12*texCoord.y+dt), colour.z-sin(3*dt), colour.w);
-  frag_colour = vec4(colour.x, colour.y, colour.z, colour.w);
+  frag_colour = vec4(colour.x, colour.y, colour.z, 1);
 }
     |]
 

--- a/src/Horture.hs
+++ b/src/Horture.hs
@@ -1,1 +1,333 @@
-module Horture () where
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Horture
+  ( SizeUpdate (..),
+    hortureName,
+    listenResizeEvent,
+    resizeWindow,
+    verts,
+    floatSize,
+    planeVertsSize,
+    vertsElement,
+    vertsElementSize,
+    ximageData,
+    initResources,
+    initGLFW,
+  )
+where
+
+import Control.Monad.Except
+import Data.ByteString.Char8 (ByteString, pack)
+import Data.Functor ((<&>))
+import Data.IORef
+import Data.List (find)
+import Data.Word
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import Foreign.Storable
+import Graphics.GLUtil as Util hiding (throwError)
+import Graphics.Rendering.OpenGL as GL hiding (Color, flush)
+import qualified Graphics.UI.GLFW as GLFW
+import Graphics.X11 hiding (resizeWindow)
+import Graphics.X11.Xlib.Extras
+import Graphics.X11.Xlib.Types
+import System.Clock
+import System.Exit
+import Text.RawString.QQ
+
+main'' :: IO ()
+main'' = do
+  dp <- openDisplay ""
+  let ds = defaultScreen dp
+      cm = defaultColormap dp ds
+  w <- rootWindow dp ds
+  attr <- getWindowAttributes dp w
+
+  let ww = fromIntegral $ wa_width attr
+      wh = fromIntegral $ wa_height attr
+      n = 6
+      loop :: Int -> IO Int
+      loop i = do
+        !img <-
+          getImage
+            dp
+            w
+            0
+            0
+            (fromIntegral ww)
+            (fromIntegral wh)
+            0xFFFFFFFF
+            zPixmap
+
+        ximageBytesPerLine img >>= \m -> print $ "BytesPerLine: " <> show m
+        ximageOffset img >>= \m -> print $ "Offset: " <> show m
+        ximagebitsPerPixel img >>= \m -> print $ "BitsPerPixel: " <> show m
+
+        -- GetPixel query.
+        let x = 1
+            y = 0
+            px = getPixel img x y
+        queryColor dp cm (Color (fromIntegral px) 0 0 0 0)
+          >>= \(Color _ r g b _) -> print $ "GetPixel: " <> show (r, g, b)
+
+        -- Custom query.
+        buf <- ximageData img
+        let stride = 4
+            -- 3840x1080
+            idx = 3840 * 1080 * stride
+        peekByteOff @Word8 buf (idx + 0)
+          >>= \r ->
+            peekByteOff @Word8 buf (idx + 4)
+              >>= \g ->
+                peekByteOff @Word8 buf (idx + 8)
+                  >>= \b -> print $ "Image Inspect: " <> show (r, g, b)
+        if i < n then loop (i + 1) else return i
+
+  start <- getTime Monotonic
+  r <- loop 0
+  end <- getTime Monotonic
+
+  let dt = nsec (end - start)
+      frameTime = fromIntegral dt / fromIntegral n
+
+  print $ "r: " <> show r
+  print $ "dt: " <> show dt
+  print $ "n: " <> show n
+  print $ "FrameTime (ms): " <> show (frameTime / (10 ^ 6))
+
+  print "Done..."
+
+xtest :: IO ()
+xtest = do
+  dp <- openDisplay ""
+  let ds = defaultScreen dp
+      cm = defaultColormap dp ds
+  w <- rootWindow dp ds
+  (root, parent, childs) <- queryTree dp w
+  res <-
+    mapM
+      ( \c ->
+          fetchName dp c >>= \case
+            Nothing -> return ("", c)
+            Just w -> return (w, c)
+      )
+      childs
+      <&> filter ((/=) "" . fst)
+
+  alloca $ \ptr -> do
+    mapM
+      ( \c -> do
+          s <- xGetTextProperty dp c ptr wM_CLASS
+          when (s /= 0) $ peek ptr >>= wcTextPropertyToTextList dp >>= print
+      )
+      childs
+  print "Done..."
+
+verts :: [Float]
+verts = [-1, -1, 0, 0, 1, -1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, -1, 0, 1, 1]
+
+vertsElement :: [GLuint]
+vertsElement = [0, 1, 2, 0, 2, 3]
+
+uintSize :: Int
+uintSize = sizeOf @GLuint undefined
+
+floatSize :: Int
+floatSize = sizeOf @Float undefined
+
+planeVertsSize :: Int
+planeVertsSize = length verts * floatSize
+
+vertsElementSize :: Int
+vertsElementSize = length vertsElement * uintSize
+
+imgPtr :: Image -> Ptr Image
+imgPtr (Image p) = p
+
+szCInt :: Int
+szCInt = sizeOf @CInt undefined
+
+ximageData :: Image -> IO (Ptr Word8)
+ximageData (Image p) = peek (plusPtr @Image @(Ptr CIntPtr) p xdataPtr) >>= \buf -> return . castPtr $ buf
+  where
+    szCint = sizeOf @CInt undefined
+    xdataPtr = 4 * szCint
+
+ximagebitsPerPixel :: Image -> IO CInt
+ximagebitsPerPixel (Image p) = peekByteOff @CInt (castPtr p) xbitsPerPixel
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint
+
+ximageBytesPerLine :: Image -> IO CInt
+ximageBytesPerLine (Image p) = peekByteOff @CInt (castPtr p) xbytesPerLine
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
+
+ximageOffset :: Image -> IO CInt
+ximageOffset (Image p) = peekByteOff @CInt (castPtr p) xoffset
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xwidth = 0
+    xheight = szCint
+    xoffset = 2 * szCint
+    xformat = 3 * szCint
+    xdataPtr = 4 * szCint
+    xbyteorder = 4 * szCint + szPtr
+    xbitmapUnit = 4 * szCint + szPtr + szCint
+    xbitmapBitOrder = 4 * szCint + szPtr + 2 * szCint
+    xbitmapPad = 4 * szCint + szPtr + 3 * szCint
+    xdepth = 4 * szCint + szPtr + 4 * szCint
+    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
+    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint
+
+initGLFW :: IO GLFW.Window
+initGLFW = do
+  i <- GLFW.init
+  unless i $ print "GLFW.init failed" >> exitFailure
+
+  GLFW.defaultWindowHints
+  GLFW.windowHint $ GLFW.WindowHint'Floating True
+  GLFW.windowHint $ GLFW.WindowHint'FocusOnShow False
+  GLFW.windowHint $ GLFW.WindowHint'Focused False
+  GLFW.windowHint $ GLFW.WindowHint'Decorated False
+  win <-
+    GLFW.createWindow 1024 1024 hortureName Nothing Nothing >>= \case
+      Nothing -> throwError . userError $ "Failed to create GLFW window"
+      Just win -> return win
+  GLFW.makeContextCurrent (Just win)
+  GLFW.setWindowCloseCallback win (Just shutdown)
+
+  return win
+
+resizeWindow :: GLFW.WindowSizeCallback
+resizeWindow _ w h = do
+  -- TODO: GLFW.resizeWindow here?
+  GL.viewport $= (GL.Position 0 0, GL.Size (fromIntegral w) (fromIntegral h))
+
+keyPressed :: GLFW.KeyCallback
+keyPressed win GLFW.Key'Escape _ GLFW.KeyState'Pressed _ = shutdown win
+keyPressed win GLFW.Key'Q _ GLFW.KeyState'Pressed _ = shutdown win
+keyPressed _ _ _ _ _ = return ()
+
+shutdown :: GLFW.Window -> IO ()
+shutdown win = do
+  GLFW.destroyWindow win
+  GLFW.terminate
+  void exitSuccess
+
+initResources :: IO (VertexArrayObject, BufferObject, BufferObject, Program)
+initResources = do
+  vao <- genObjectName
+  bindVertexArrayObject $= Just vao
+  vbo <- genObjectName
+  bindBuffer ArrayBuffer $= Just vbo
+  vsp <- loadShaderBS "vertex.shader" VertexShader hortureVertexShader
+  fsp <- loadShaderBS "fragment.shader" FragmentShader hortureFragmentShader
+  prog <- linkShaderProgram [vsp, fsp]
+  currentProgram $= Just prog
+  veo <- genObjectName
+  bindBuffer ArrayBuffer $= Just veo
+  return (vao, vbo, veo, prog)
+
+iterate' :: Monad m => (Int -> Bool) -> (Int -> m ()) -> m ()
+iterate' b f = go 0 b f
+  where
+    go :: Monad m => Int -> (Int -> Bool) -> (Int -> m ()) -> m ()
+    go n b f = when (b n) $ f n >> go (n + 1) b f
+
+hortureVertexShader :: ByteString
+hortureVertexShader =
+  pack
+    [r|
+#version 410
+
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoord;
+
+out vec2 texCoord;
+
+void main() {
+  gl_Position = vec4(aPos, 1.0);
+  texCoord = aTexCoord;
+}
+   |]
+
+hortureFragmentShader :: ByteString
+hortureFragmentShader =
+  pack
+    [r|
+#version 410
+
+in vec2 texCoord;
+
+uniform sampler2D texture1;
+
+out vec4 frag_colour;
+
+void main() {
+  frag_colour = texture(texture1, texCoord);
+}
+    |]
+
+data SizeUpdate = GLFWUpdate (Int, Int) | XUpdate (CInt, CInt) deriving (Show, Eq)
+
+listenResizeEvent :: Display -> Window -> GLFW.Window -> IORef (Drawable, (CInt, CInt)) -> IO ()
+listenResizeEvent dp w glW r = go
+  where
+    go = do
+      allocaXEvent $ \evptr -> do
+        doIt <- checkWindowEvent dp w structureNotifyMask evptr
+        when doIt $ do
+          getEvent evptr >>= \case
+            ConfigureEvent {..} -> do
+              -- Retrieve a new pixmap.
+              pm <- xCompositeNameWindowPixmap dp w
+              -- Update reference, aspect ratio & destroy old pixmap.
+              pm <- atomicModifyIORef' r $ \(d, _) -> ((pm, (ev_width, ev_height)), d)
+              freePixmap dp pm
+              -- Update overlay window with new aspect ratio.
+              let w = fromIntegral ev_width
+                  h = fromIntegral ev_height
+              GLFW.setWindowSize glW w h
+            _ -> return ()
+      go
+
+findClassName :: Display -> Window -> String -> IO (Maybe Window)
+findClassName dp w n = do
+  (root, parent, childs) <- queryTree dp w
+  alloca $ \ptr -> do
+    res <-
+      mapM
+        ( \c -> do
+            s <- xGetTextProperty dp c ptr wM_CLASS
+            if s /= 0
+              then
+                peek ptr
+                  >>= wcTextPropertyToTextList dp
+                  >>= \ss ->
+                    case find (n ==) ss of
+                      Nothing -> return (Nothing @Window)
+                      Just _ -> print ss >> return (Just c)
+              else return (Nothing @Window)
+        )
+        childs
+    case res of
+      [] -> return Nothing
+      fs -> case filter (/= Nothing) fs of
+        -- Xlib how to keep drawing unfocused window:
+        -- https://linux.die.net/man/3/xcompositenamewindowpixmap
+        xs@(_ : _) -> print xs >> return (last xs)
+        _ -> return Nothing
+
+hortureName :: String
+hortureName = "horture"

--- a/src/Horture.hs
+++ b/src/Horture.hs
@@ -18,7 +18,7 @@ module Horture
     initResources,
     initGLFW,
     m44ToGLmatrix,
-    modelForAspectRatio,
+    scaleForAspectRatio,
     projectionForAspectRatio,
     degToRad,
     identityM44,
@@ -261,11 +261,12 @@ layout (location = 1) in vec2 aTexCoord;
 uniform mat4 model;
 uniform mat4 view;
 uniform mat4 proj;
+uniform float dt;
 
 out vec2 texCoord;
 
 void main() {
-  gl_Position = proj * view * model * vec4(aPos, 1.0);
+  gl_Position = proj * view * model * vec4(aPos.x, aPos.y, aPos.z, 1.0);
   texCoord = aTexCoord;
 }
    |]
@@ -278,6 +279,7 @@ hortureFragmentShader =
 
 in vec2 texCoord;
 
+uniform float dt;
 uniform sampler2D texture1;
 
 out vec4 frag_colour;
@@ -375,8 +377,8 @@ m44ToGLmatrix m = withNewMatrix ColumnMajor (\p -> poke (castPtr p) m')
 degToRad :: Float -> Float
 degToRad = (*) (pi / 180)
 
-modelForAspectRatio :: (Float, Float) -> M44 Float
-modelForAspectRatio (ww, wh) = model
+scaleForAspectRatio :: (Float, Float) -> M44 Float
+scaleForAspectRatio (ww, wh) = model
   where
     ident = identityM44
     aspectRatio = ww / wh
@@ -386,7 +388,7 @@ modelForAspectRatio (ww, wh) = model
         (V4 0 1 0 0)
         (V4 0 0 1 0)
         (V4 0 0 0 1)
-    model = scaling * ident
+    model = scaling !*! ident
 
 projectionForAspectRatio :: (Float, Float) -> M44 Float
 projectionForAspectRatio (ww, wh) = proj

--- a/src/Horture/Effect.hs
+++ b/src/Horture/Effect.hs
@@ -1,10 +1,15 @@
 module Horture.Effect (Effect (..), GifType (..)) where
 
+import Horture.Object
+import Linear.V3
+
 data GifType = Ricardo
   deriving (Show)
 
+type Position = V3 Float
+
 data Effect
-  = AddGif GifType
+  = AddGif GifType Lifetime Position
   | ShakeIt
   | ZoomIt
   | FlipIt

--- a/src/Horture/Effect.hs
+++ b/src/Horture/Effect.hs
@@ -1,0 +1,15 @@
+module Horture.Effect (Effect (..), GifType (..)) where
+
+data GifType = Ricardo
+  deriving (Show)
+
+data Effect
+  = AddGif GifType
+  | ShakeIt
+  | ZoomIt
+  | FlipIt
+  | Rollercoaster
+  | BlazeIt
+  | Flashbang
+  | Noop
+  deriving (Show)

--- a/src/Horture/Error.hs
+++ b/src/Horture/Error.hs
@@ -1,0 +1,3 @@
+module Horture.Error (HortureError(..)) where
+
+newtype HortureError = HE String deriving (Show)

--- a/src/Horture/Horture.hs
+++ b/src/Horture/Horture.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Horture.Horture (Horture, runHorture) where
+
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Horture.State
+import Horture.Error
+
+type Horture a = ExceptT HortureError (StateT HortureState (ReaderT HortureStatic IO)) a
+
+runHorture :: HortureState -> HortureStatic -> Horture a -> IO (Either HortureError a)
+runHorture ss rs = flip runReaderT rs . flip evalStateT ss . runExceptT

--- a/src/Horture/Horture.hs
+++ b/src/Horture/Horture.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
-
 module Horture.Horture (Horture, runHorture) where
 
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
-import Horture.State
 import Horture.Error
+import Horture.State
 
 type Horture a = ExceptT HortureError (StateT HortureState (ReaderT HortureStatic IO)) a
 

--- a/src/Horture/Object.hs
+++ b/src/Horture/Object.hs
@@ -56,14 +56,14 @@ class Renderable o where
 instance Renderable Object where
   model o = m
     where
-      trans = mkTransformation @Float (_orientation o) (V3 0 0 0)
+      trans = mkTransformation @Float (_orientation o) (_pos o)
       m = trans !*! _scale o
 
 defScreen :: Object
 defScreen =
   Object
     { _id = 0,
-      _pos = V3 0 0 0,
+      _pos = V3 0 0 (-1),
       _orientation = Quaternion 1 (V3 0 0 0),
       _scale =
         V4

--- a/src/Horture/Object.hs
+++ b/src/Horture/Object.hs
@@ -41,6 +41,8 @@ data Object = Object
     _lifetime :: Lifetime,
     _birth :: Double,
     _textureType :: TextureType,
+    _textureLength :: Int,
+    _delay :: Int,
     _voice :: Maybe Voice
     -- _attributes :: [Attribute]
   }
@@ -72,11 +74,13 @@ defScreen =
       _lifetime = Forever,
       _birth = 0,
       _textureType = Background,
+      _textureLength = 1,
+      _delay = 0,
       _voice = Nothing
     }
 
-defGif :: Int -> Double -> Lifetime -> Object
-defGif id birth lifetime =
+defGif :: Int -> Double -> Lifetime -> Int -> Int -> Object
+defGif id birth lifetime numOfImgs delayms =
   Object
     { _id = id,
       _pos = V3 0 0 0,
@@ -90,6 +94,8 @@ defGif id birth lifetime =
       _lifetime = lifetime,
       _birth = birth,
       _textureType = Gif,
+      _textureLength = numOfImgs,
+      _delay = delayms,
       _voice = Nothing
     }
 

--- a/src/Horture/Object.hs
+++ b/src/Horture/Object.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Horture.Object
+  ( Object (..),
+    Lifetime (..),
+    Renderable (..),
+    defScreen,
+    defGif,
+    isStillAlive,
+  )
+where
+
+import Linear.Matrix
+import Linear.Quaternion
+import Linear.V3
+import Linear.V4
+
+-- Lifetime describes for how long an object can live. Either forever or for a
+-- limited time. Limited defines the lifetime in seconds.
+data Lifetime = Forever | Limited Double deriving (Show, Eq)
+
+data TextureType
+  = Background
+  | Gif
+  | Image
+  deriving (Show, Eq)
+
+-- Voice will be eventual soundfiles associated with gifs.
+data Voice = Voice
+  deriving (Show, Eq)
+
+-- Object is a horture object which can be rendered. Every horture object is in
+-- essence a quad with a position, orientation and scale. For animation
+-- purposes each object also has a time of birth and overall lifetime.
+data Object = Object
+  { _id :: Int,
+    _pos :: V3 Float,
+    _orientation :: Quaternion Float,
+    _scale :: M44 Float,
+    _lifetime :: Lifetime,
+    _birth :: Double,
+    _textureType :: TextureType,
+    _voice :: Maybe Voice
+    -- _attributes :: [Attribute]
+  }
+  deriving (Show, Eq)
+
+-- Renderable is every object capable of giving a model description in form of
+-- a M44 matrix.
+class Renderable o where
+  model :: o -> M44 Float
+
+instance Renderable Object where
+  model o = m
+    where
+      trans = mkTransformation @Float (_orientation o) (V3 0 0 0)
+      m = trans !*! _scale o
+
+defScreen :: Object
+defScreen =
+  Object
+    { _id = 0,
+      _pos = V3 0 0 0,
+      _orientation = Quaternion 1 (V3 0 0 0),
+      _scale =
+        V4
+          (V4 1 0 0 0)
+          (V4 0 1 0 0)
+          (V4 0 0 1 0)
+          (V4 0 0 0 1),
+      _lifetime = Forever,
+      _birth = 0,
+      _textureType = Background,
+      _voice = Nothing
+    }
+
+defGif :: Int -> Double -> Lifetime -> Object
+defGif id birth lifetime =
+  Object
+    { _id = id,
+      _pos = V3 0 0 0,
+      _orientation = Quaternion 1 (V3 0 0 0),
+      _scale =
+        V4
+          (V4 1 0 0 0)
+          (V4 0 1 0 0)
+          (V4 0 0 1 0)
+          (V4 0 0 0 1),
+      _lifetime = lifetime,
+      _birth = birth,
+      _textureType = Gif,
+      _voice = Nothing
+    }
+
+isStillAlive :: Double -> Object -> Bool
+isStillAlive timeNow o = case _lifetime o of
+  Forever -> True
+  Limited s -> (timeNow - _birth o) <= s

--- a/src/Horture/Render.hs
+++ b/src/Horture/Render.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Horture.Render
+  ( renderObjects,
+    renderScreen,
+  )
+where
+
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Foreign.Ptr
+import Foreign.Storable
+import Graphics.Rendering.OpenGL hiding (get)
+import qualified Graphics.UI.GLFW as GLFW
+import Graphics.X11
+import Horture.Horture
+import Horture.Object
+import Horture.Scene
+import Horture.State
+import Horture.X11
+import Linear.Matrix
+
+
+renderObjects :: Double -> [Object] -> Horture ()
+renderObjects dt os = do
+  gifProg <- asks _gifProg
+  gifTex <- asks _gifTexUnit
+  gifIndex <- asks _gifIndex
+  modelUniform <- asks _modelUniform
+  liftIO $ currentProgram $= Just gifProg
+  activeTexture $= gifTex
+  go gifIndex modelUniform os
+  liftIO $ drawElements Triangles 6 UnsignedInt nullPtr
+  where
+    go :: UniformLocation -> UniformLocation -> [Object] -> Horture ()
+    go _ _ [] = return ()
+    go gifIndex modelUniform (o : os) = do
+      let elapsedms = round $ dt * (10 ^ (2 :: Int))
+          i = (elapsedms `div` (10 * _delay o)) `mod` _textureLength o
+      liftIO $ m44ToGLmatrix (model o) >>= (uniform modelUniform $=)
+      liftIO $ uniform gifIndex $= fromIntegral @_ @GLint i
+      go gifIndex modelUniform os
+
+-- renderScreen renders the captured application window. It is assumed that the
+-- horture texture was already initialized at this point.
+renderScreen :: Double -> Object -> Horture ()
+renderScreen _ s = do
+  modelUniform <- asks _modelUniform
+  backgroundProg <- asks _backgroundProg
+  screenTexUnit <- asks _screenTexUnit
+  (HortureState dp pm dim) <- get
+  liftIO $ currentProgram $= Just backgroundProg
+  activeTexture $= screenTexUnit
+  liftIO $ getWindowImage dp pm dim >>= updateWindowTexture dim
+  liftIO $ m44ToGLmatrix (model s) >>= (uniform modelUniform $=)
+  liftIO $ drawElements Triangles 6 UnsignedInt nullPtr
+
+-- m44ToGLmatrix converts the row based representation of M44 to a GLmatrix
+-- representation which is column based.
+m44ToGLmatrix :: (Show a, MatrixComponent a) => M44 a -> IO (GLmatrix a)
+m44ToGLmatrix m = withNewMatrix ColumnMajor (\p -> poke (castPtr p) m')
+  where
+    m' = transpose m
+
+-- getWindowImage fetches the image of the currently captured application
+-- window.
+getWindowImage :: Display -> Drawable -> (Int, Int) -> IO Image
+getWindowImage dp pm (w, h) =
+  getImage
+    dp
+    pm
+    1
+    1
+    (fromIntegral w)
+    (fromIntegral h)
+    0xFFFFFFFF
+    zPixmap
+
+updateWindowTexture :: (Int, Int) -> Image -> IO ()
+updateWindowTexture (w, h) i = do
+  src <- ximageData i
+  let pd = PixelData BGRA UnsignedInt8888Rev src
+  texSubImage2D
+    Texture2D
+    0
+    (TexturePosition2D 0 0)
+    (TextureSize2D (fromIntegral w) (fromIntegral h))
+    pd
+  destroyImage i

--- a/src/Horture/Render.hs
+++ b/src/Horture/Render.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Horture.Render
@@ -13,48 +12,62 @@ import Control.Monad.State
 import Foreign.Ptr
 import Foreign.Storable
 import Graphics.Rendering.OpenGL hiding (get)
-import qualified Graphics.UI.GLFW as GLFW
 import Graphics.X11
 import Horture.Horture
 import Horture.Object
-import Horture.Scene
 import Horture.State
 import Horture.X11
 import Linear.Matrix
-
+import Linear.V4
 
 renderObjects :: Double -> [Object] -> Horture ()
+renderObjects _ [] = return ()
 renderObjects dt os = do
   gifProg <- asks _gifProg
   gifTex <- asks _gifTexUnit
+  gifTexObject <- asks _gifTexObject
   gifIndex <- asks _gifIndex
-  modelUniform <- asks _modelUniform
+  modelUniform <- asks _gifModelUniform
   liftIO $ currentProgram $= Just gifProg
   activeTexture $= gifTex
+  textureBinding Texture2DArray $= Just gifTexObject
   go gifIndex modelUniform os
-  liftIO $ drawElements Triangles 6 UnsignedInt nullPtr
   where
     go :: UniformLocation -> UniformLocation -> [Object] -> Horture ()
     go _ _ [] = return ()
     go gifIndex modelUniform (o : os) = do
       let elapsedms = round $ dt * (10 ^ (2 :: Int))
           i = (elapsedms `div` (10 * _delay o)) `mod` _textureLength o
-      liftIO $ m44ToGLmatrix (model o) >>= (uniform modelUniform $=)
+      liftIO $
+        m44ToGLmatrix
+          ( model o
+              !*! V4
+                (V4 0.5 0 0 0)
+                (V4 0 0.5 0 0)
+                (V4 0 0 0.5 0)
+                (V4 0 0 0 1)
+          )
+          >>= (uniform modelUniform $=)
       liftIO $ uniform gifIndex $= fromIntegral @_ @GLint i
+      liftIO $ drawElements Triangles 6 UnsignedInt nullPtr
       go gifIndex modelUniform os
 
 -- renderScreen renders the captured application window. It is assumed that the
 -- horture texture was already initialized at this point.
 renderScreen :: Double -> Object -> Horture ()
 renderScreen _ s = do
-  modelUniform <- asks _modelUniform
   backgroundProg <- asks _backgroundProg
+  modelUniform <- asks _modelUniform
   screenTexUnit <- asks _screenTexUnit
-  (HortureState dp pm dim) <- get
+  screenTexObject <- asks _screenTexObject
+  (HortureState dp _ pm dim) <- get
   liftIO $ currentProgram $= Just backgroundProg
   activeTexture $= screenTexUnit
+  textureBinding Texture2D $= Just screenTexObject
   liftIO $ getWindowImage dp pm dim >>= updateWindowTexture dim
-  liftIO $ m44ToGLmatrix (model s) >>= (uniform modelUniform $=)
+  let scale = scaleForAspectRatio dim
+      m = model s !*! scale
+  liftIO $ m44ToGLmatrix m >>= (uniform modelUniform $=)
   liftIO $ drawElements Triangles 6 UnsignedInt nullPtr
 
 -- m44ToGLmatrix converts the row based representation of M44 to a GLmatrix
@@ -63,6 +76,27 @@ m44ToGLmatrix :: (Show a, MatrixComponent a) => M44 a -> IO (GLmatrix a)
 m44ToGLmatrix m = withNewMatrix ColumnMajor (\p -> poke (castPtr p) m')
   where
     m' = transpose m
+
+identityM44 :: M44 Float
+identityM44 =
+  V4
+    (V4 1 0 0 0)
+    (V4 0 1 0 0)
+    (V4 0 0 1 0)
+    (V4 0 0 0 1)
+
+scaleForAspectRatio :: (Int, Int) -> M44 Float
+scaleForAspectRatio (ww, wh) = model
+  where
+    ident = identityM44
+    aspectRatio = fromIntegral ww / fromIntegral wh
+    scaling =
+      V4
+        (V4 aspectRatio 0 0 0)
+        (V4 0 1 0 0)
+        (V4 0 0 1 0)
+        (V4 0 0 0 1)
+    model = scaling !*! ident
 
 -- getWindowImage fetches the image of the currently captured application
 -- window.
@@ -88,4 +122,5 @@ updateWindowTexture (w, h) i = do
     (TexturePosition2D 0 0)
     (TextureSize2D (fromIntegral w) (fromIntegral h))
     pd
+  generateMipmap' Texture2D
   destroyImage i

--- a/src/Horture/Scene.hs
+++ b/src/Horture/Scene.hs
@@ -1,0 +1,45 @@
+module Horture.Scene
+  ( apply,
+    applyAll,
+    Scene (..),
+    purge,
+  )
+where
+
+import Horture.Effect
+import Horture.Object
+
+-- Scene is the horture scene. It consists of the background plane, which is
+-- the screen being hortured as well as transient multiple objects in an
+-- independent overlay.
+data Scene = Scene
+  { _screen :: Object,
+    _objects :: [Object]
+  }
+
+-- apply applies the given effect at the time given using the elapsed time
+-- since the last frame to the scene.
+apply :: Double -> Double -> Effect -> Scene -> Scene
+apply timeNow dt Noop s = s
+apply timeNow dt (AddGif t) s = addGif t timeNow dt s
+apply timeNow dt ShakeIt s = s
+apply timeNow dt ZoomIt s = s
+apply timeNow dt FlipIt s = s
+apply timeNow dt Rollercoaster s = s
+apply timeNow dt BlazeIt s = s
+apply timeNow dt Flashbang s = s
+
+-- applyAll composes all given effects at the time given time using the time
+-- since the last frame as a progression point.
+applyAll :: [Effect] -> Double -> Double -> Scene -> Scene
+applyAll effs timeNow dt s = foldr (apply timeNow dt) s (Noop : effs)
+
+addGif :: GifType -> Double -> Double -> Scene -> Scene
+addGif Ricardo timeNow _ s = s {_objects = o : _objects s}
+  where
+    o = defGif 0 timeNow (Limited 8)
+
+-- purge purges the given scene using timenow by removing all transient objects
+-- which died off.
+purge :: Double -> Scene -> Scene
+purge timeNow s = s {_objects = filter (isStillAlive timeNow) . _objects $ s}

--- a/src/Horture/Scene.hs
+++ b/src/Horture/Scene.hs
@@ -14,20 +14,20 @@ import Horture.Object
 -- independent overlay.
 data Scene = Scene
   { _screen :: Object,
-    _objects :: [Object]
+    _gifs :: [Object]
   }
 
 -- apply applies the given effect at the time given using the elapsed time
 -- since the last frame to the scene.
 apply :: Double -> Double -> Effect -> Scene -> Scene
-apply timeNow dt Noop s = s
+apply _timeNow _dt Noop s = s
 apply timeNow dt (AddGif t) s = addGif t timeNow dt s
-apply timeNow dt ShakeIt s = s
-apply timeNow dt ZoomIt s = s
-apply timeNow dt FlipIt s = s
-apply timeNow dt Rollercoaster s = s
-apply timeNow dt BlazeIt s = s
-apply timeNow dt Flashbang s = s
+apply _timeNow _dt ShakeIt s = s
+apply _timeNow _dt ZoomIt s = s
+apply _timeNow _dt FlipIt s = s
+apply _timeNow _dt Rollercoaster s = s
+apply _timeNow _dt BlazeIt s = s
+apply _timeNow _dt Flashbang s = s
 
 -- applyAll composes all given effects at the time given time using the time
 -- since the last frame as a progression point.
@@ -35,11 +35,11 @@ applyAll :: [Effect] -> Double -> Double -> Scene -> Scene
 applyAll effs timeNow dt s = foldr (apply timeNow dt) s (Noop : effs)
 
 addGif :: GifType -> Double -> Double -> Scene -> Scene
-addGif Ricardo timeNow _ s = s {_objects = o : _objects s}
+addGif Ricardo timeNow _ s = s {_gifs = o : _gifs s}
   where
-    o = defGif 0 timeNow (Limited 8)
+    o = defGif 0 timeNow (Limited 8) 20 2
 
 -- purge purges the given scene using timenow by removing all transient objects
 -- which died off.
 purge :: Double -> Scene -> Scene
-purge timeNow s = s {_objects = filter (isStillAlive timeNow) . _objects $ s}
+purge timeNow s = s {_gifs = filter (isStillAlive timeNow) . _gifs $ s}

--- a/src/Horture/Scene.hs
+++ b/src/Horture/Scene.hs
@@ -2,12 +2,14 @@ module Horture.Scene
   ( apply,
     applyAll,
     Scene (..),
+    addGif,
     purge,
   )
 where
 
 import Horture.Effect
 import Horture.Object
+import Linear.V3
 
 -- Scene is the horture scene. It consists of the background plane, which is
 -- the screen being hortured as well as transient multiple objects in an
@@ -21,7 +23,7 @@ data Scene = Scene
 -- since the last frame to the scene.
 apply :: Double -> Double -> Effect -> Scene -> Scene
 apply _timeNow _dt Noop s = s
-apply timeNow dt (AddGif t) s = addGif t timeNow dt s
+apply timeNow _dt (AddGif t lt pos) s = addGif t timeNow lt pos s
 apply _timeNow _dt ShakeIt s = s
 apply _timeNow _dt ZoomIt s = s
 apply _timeNow _dt FlipIt s = s
@@ -34,10 +36,10 @@ apply _timeNow _dt Flashbang s = s
 applyAll :: [Effect] -> Double -> Double -> Scene -> Scene
 applyAll effs timeNow dt s = foldr (apply timeNow dt) s (Noop : effs)
 
-addGif :: GifType -> Double -> Double -> Scene -> Scene
-addGif Ricardo timeNow _ s = s {_gifs = o : _gifs s}
+addGif :: GifType -> Double -> Lifetime -> V3 Float -> Scene -> Scene
+addGif Ricardo timeNow lt pos s = s {_gifs = o : _gifs s}
   where
-    o = defGif 0 timeNow (Limited 8) 20 2
+    o = (defGif 0 timeNow lt 20 2) {_pos = pos}
 
 -- purge purges the given scene using timenow by removing all transient objects
 -- which died off.

--- a/src/Horture/State.hs
+++ b/src/Horture/State.hs
@@ -1,0 +1,29 @@
+module Horture.State
+  ( HortureStatic (..),
+    HortureState (..),
+  )
+where
+
+import Graphics.Rendering.OpenGL hiding (get)
+import Graphics.X11
+
+data HortureStatic = HortureStatic
+  { _backgroundProg :: Program,
+    _gifProg :: Program,
+    _modelUniform :: UniformLocation,
+    _viewUniform :: UniformLocation,
+    _projUniform :: UniformLocation,
+    _planeVertexLocation :: AttribLocation,
+    _planeTexLocation :: AttribLocation,
+    _screenTexUnit :: TextureUnit,
+    _gifTexUnit :: TextureUnit,
+    _gifIndex :: UniformLocation,
+    _backgroundColor :: Color4 Float
+  }
+  deriving (Show)
+
+data HortureState = HortureState
+  { _display :: Display,
+    _capture :: Drawable,
+    _dim :: (Int, Int)
+  }

--- a/src/Horture/State.hs
+++ b/src/Horture/State.hs
@@ -5,6 +5,7 @@ module Horture.State
 where
 
 import Graphics.Rendering.OpenGL hiding (get)
+import qualified Graphics.UI.GLFW as GLFW
 import Graphics.X11
 
 data HortureStatic = HortureStatic
@@ -16,14 +17,19 @@ data HortureStatic = HortureStatic
     _planeVertexLocation :: AttribLocation,
     _planeTexLocation :: AttribLocation,
     _screenTexUnit :: TextureUnit,
+    _screenTexObject :: TextureObject,
+    _gifModelUniform :: UniformLocation,
     _gifTexUnit :: TextureUnit,
+    _gifTexObject :: TextureObject,
     _gifIndex :: UniformLocation,
+    _glWin :: GLFW.Window,
     _backgroundColor :: Color4 Float
   }
   deriving (Show)
 
 data HortureState = HortureState
   { _display :: Display,
+    _xWin :: Window,
     _capture :: Drawable,
     _dim :: (Int, Int)
   }

--- a/src/Horture/X11.hs
+++ b/src/Horture/X11.hs
@@ -1,13 +1,15 @@
 {-# LANGUAGE TypeApplications #-}
 
-module Horture.X11 (
-    imgPtr,
+module Horture.X11
+  ( imgPtr,
     szCInt,
     ximageData,
     ximagebitsPerPixel,
     ximageBytesPerLine,
     ximageOffset,
-    ) where
+    ximageDepth,
+  )
+where
 
 import Data.Word
 import Foreign.C.Types
@@ -41,6 +43,13 @@ ximageBytesPerLine (Image p) = peekByteOff @CInt (castPtr p) xbytesPerLine
     szCint = sizeOf @CInt undefined
     szPtr = sizeOf @CIntPtr undefined
     xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
+
+ximageDepth :: Image -> IO CInt
+ximageDepth (Image p) = peekByteOff @CInt (castPtr p) xdepth
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xdepth = 4 * szCint + szPtr + 4 * szCint
 
 ximageOffset :: Image -> IO CInt
 ximageOffset (Image p) = peekByteOff @CInt (castPtr p) xoffset

--- a/src/Horture/X11.hs
+++ b/src/Horture/X11.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Horture.X11 (
+    imgPtr,
+    szCInt,
+    ximageData,
+    ximagebitsPerPixel,
+    ximageBytesPerLine,
+    ximageOffset,
+    ) where
+
+import Data.Word
+import Foreign.C.Types
+import Foreign.Ptr
+import Foreign.Storable
+import Graphics.X11
+import Graphics.X11.Xlib.Types
+
+imgPtr :: Image -> Ptr Image
+imgPtr (Image p) = p
+
+szCInt :: Int
+szCInt = sizeOf @CInt undefined
+
+ximageData :: Image -> IO (Ptr Word8)
+ximageData (Image p) = peek (plusPtr @Image @(Ptr CIntPtr) p xdataPtr) >>= \buf -> return . castPtr $ buf
+  where
+    szCint = sizeOf @CInt undefined
+    xdataPtr = 4 * szCint
+
+ximagebitsPerPixel :: Image -> IO CInt
+ximagebitsPerPixel (Image p) = peekByteOff @CInt (castPtr p) xbitsPerPixel
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint
+
+ximageBytesPerLine :: Image -> IO CInt
+ximageBytesPerLine (Image p) = peekByteOff @CInt (castPtr p) xbytesPerLine
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
+
+ximageOffset :: Image -> IO CInt
+ximageOffset (Image p) = peekByteOff @CInt (castPtr p) xoffset
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xwidth = 0
+    xheight = szCint
+    xoffset = 2 * szCint
+    xformat = 3 * szCint
+    xdataPtr = 4 * szCint
+    xbyteorder = 4 * szCint + szPtr
+    xbitmapUnit = 4 * szCint + szPtr + szCint
+    xbitmapBitOrder = 4 * szCint + szPtr + 2 * szCint
+    xbitmapPad = 4 * szCint + szPtr + 3 * szCint
+    xdepth = 4 * szCint + szPtr + 4 * szCint
+    xbytesPerLine = 4 * szCint + szPtr + 5 * szCint
+    xbitsPerPixel = 4 * szCint + szPtr + 6 * szCint

--- a/src/Horture/X11.hs
+++ b/src/Horture/X11.hs
@@ -7,6 +7,11 @@ module Horture.X11
     ximagebitsPerPixel,
     ximageBytesPerLine,
     ximageOffset,
+    ximageBitmapUnit,
+    ximageBitmapPad,
+    ximageRMask,
+    ximageGMask,
+    ximageBMask,
     ximageDepth,
   )
 where
@@ -50,6 +55,43 @@ ximageDepth (Image p) = peekByteOff @CInt (castPtr p) xdepth
     szCint = sizeOf @CInt undefined
     szPtr = sizeOf @CIntPtr undefined
     xdepth = 4 * szCint + szPtr + 4 * szCint
+
+ximageRMask :: Image -> IO CULong
+ximageRMask (Image p) = peekByteOff @CULong (castPtr p) xrmask
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xrmask = 4 * szCint + szPtr + 7 * szCint
+
+ximageGMask :: Image -> IO CULong
+ximageGMask (Image p) = peekByteOff @CULong (castPtr p) xgmask
+  where
+    szCint = sizeOf @CInt undefined
+    szCULong = sizeOf @CULong undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xgmask = 4 * szCint + szPtr + 7 * szCint + 1 * szCULong
+
+ximageBMask :: Image -> IO CULong
+ximageBMask (Image p) = peekByteOff @CULong (castPtr p) xgmask
+  where
+    szCint = sizeOf @CInt undefined
+    szCULong = sizeOf @CULong undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xgmask = 4 * szCint + szPtr + 7 * szCint + 2 * szCULong
+
+ximageBitmapUnit :: Image -> IO CInt
+ximageBitmapUnit (Image p) = peekByteOff @CInt (castPtr p) xbitmapUnit
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbitmapUnit = 4 * szCint + szPtr + szCint
+
+ximageBitmapPad :: Image -> IO CInt
+ximageBitmapPad (Image p) = peekByteOff @CInt (castPtr p) xbitmapPad
+  where
+    szCint = sizeOf @CInt undefined
+    szPtr = sizeOf @CIntPtr undefined
+    xbitmapPad = 4 * szCint + szPtr + 3 * szCint
 
 ximageOffset :: Image -> IO CInt
 ximageOffset (Image p) = peekByteOff @CInt (castPtr p) xoffset


### PR DESCRIPTION
Using `xCompositor` to redirect the source image for X windows to an offscreen target, grabbing the data, piping it to OpenGL and modifying the view.